### PR TITLE
Performance optimizations

### DIFF
--- a/app/src/main/java/ch/logixisland/anuto/business/wave/WaveAttender.java
+++ b/app/src/main/java/ch/logixisland/anuto/business/wave/WaveAttender.java
@@ -178,8 +178,8 @@ class WaveAttender implements Enemy.Listener {
         enemy.setupPath(path.getWayPoints());
 
         Vector2 startPosition = path.getWayPoints().get(0);
-        Vector2 startDirection = startPosition.to(path.getWayPoints().get(1)).norm();
-        enemy.setPosition(startPosition.add(startDirection.mul(-offset)));
+        Vector2 startDirection = startPosition.directionTo(path.getWayPoints().get(1));
+        enemy.setPosition(Vector2.mul(startDirection, -offset).add(startPosition));
 
         return enemy;
     }

--- a/app/src/main/java/ch/logixisland/anuto/engine/logic/entity/Entity.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/logic/entity/Entity.java
@@ -24,8 +24,8 @@ public abstract class Entity {
 
     public static Predicate<Entity> onLine(final Vector2 p1, final Vector2 p2, final float lineWidth) {
         return entity -> {
-            Vector2 line = p1.to(p2);
-            Vector2 toObj = p1.to(entity.mPosition);
+            Vector2 line = Vector2.to(p1, p2);
+            Vector2 toObj = Vector2.to(p1, entity.mPosition);
             Vector2 proj = toObj.proj(line);
 
             // check whether object is after line end
@@ -38,7 +38,7 @@ public abstract class Entity {
                 return false;
             }
 
-            return proj.to(toObj).len() <= lineWidth / 2f;
+            return proj.distanceTo(toObj) <= lineWidth / 2f;
 
         };
     }
@@ -125,8 +125,9 @@ public abstract class Entity {
         mPosition = position;
     }
 
+    // note: overwrites offset
     public void move(Vector2 offset) {
-        mPosition = mPosition.add(offset);
+        mPosition = offset.add(mPosition);
     }
 
     public float getDistanceTo(Entity target) {
@@ -134,7 +135,7 @@ public abstract class Entity {
     }
 
     public float getDistanceTo(Vector2 target) {
-        return mPosition.to(target).len();
+        return mPosition.distanceTo(target);
     }
 
     public Vector2 getDirectionTo(Entity target) {
@@ -142,7 +143,7 @@ public abstract class Entity {
     }
 
     public Vector2 getDirectionTo(Vector2 target) {
-        return mPosition.to(target).norm();
+        return mPosition.directionTo(target);
     }
 
     public float getAngleTo(Entity target) {
@@ -150,7 +151,7 @@ public abstract class Entity {
     }
 
     public float getAngleTo(Vector2 target) {
-        return mPosition.to(target).angle();
+        return mPosition.angleTo(target);
     }
 
     public boolean isPositionVisible() {

--- a/app/src/main/java/ch/logixisland/anuto/engine/logic/map/GameMap.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/logic/map/GameMap.java
@@ -36,10 +36,10 @@ public class GameMap {
     }
 
     public Collection<PlateauInfo> getPlateaus() {
-        return Collections.unmodifiableCollection(mPlateaus);
+        return mPlateaus;
     }
 
     public List<MapPath> getPaths() {
-        return Collections.unmodifiableList(mPaths);
+        return mPaths;
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/engine/logic/map/MapPath.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/logic/map/MapPath.java
@@ -14,7 +14,7 @@ public class MapPath {
     }
 
     public List<Vector2> getWayPoints() {
-        return Collections.unmodifiableList(mWayPoints);
+        return mWayPoints;
     }
 
 }

--- a/app/src/main/java/ch/logixisland/anuto/engine/logic/map/WaveInfo.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/logic/map/WaveInfo.java
@@ -25,7 +25,7 @@ public class WaveInfo {
     }
 
     public List<EnemyInfo> getEnemies() {
-        return Collections.unmodifiableList(mEnemies);
+        return mEnemies;
     }
 
     public int getExtend() {

--- a/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteInstance.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteInstance.java
@@ -44,7 +44,7 @@ public abstract class SpriteInstance implements Drawable {
         canvas.save();
 
         if (mListener != null) {
-            mListener.draw(this, new SpriteTransformer(canvas));
+            mListener.draw(this, canvas);
         }
 
         Bitmap bitmap = mTemplate.getBitmaps().get(getIndex());

--- a/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteTransformation.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteTransformation.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.engine.render.sprite;
 
+import android.graphics.Canvas;
+
 public interface SpriteTransformation {
-    void draw(SpriteInstance sprite, SpriteTransformer transformer);
+    void draw(SpriteInstance sprite, Canvas canvas);
 }

--- a/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteTransformer.java
+++ b/app/src/main/java/ch/logixisland/anuto/engine/render/sprite/SpriteTransformer.java
@@ -5,25 +5,19 @@ import android.graphics.Canvas;
 import ch.logixisland.anuto.util.math.Vector2;
 
 public class SpriteTransformer {
-    private final Canvas mCanvas;
-
-    public SpriteTransformer(Canvas canvas) {
-        mCanvas = canvas;
+    public static void translate(Canvas canvas, Vector2 position) {
+        translate(canvas, position.x(), position.y());
     }
 
-    public void translate(Vector2 position) {
-        translate(position.x(), position.y());
+    public static void translate(Canvas canvas, float x, float y) {
+        canvas.translate(x, y);
     }
 
-    public void translate(float x, float y) {
-        mCanvas.translate(x, y);
+    public static void rotate(Canvas canvas, float angle) {
+        canvas.rotate(angle);
     }
 
-    public void rotate(float angle) {
-        mCanvas.rotate(angle);
-    }
-
-    public void scale(float s) {
-        mCanvas.scale(s, s);
+    public static void scale(Canvas canvas, float s) {
+        canvas.scale(s, s);
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/AreaObserver.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/AreaObserver.java
@@ -1,5 +1,6 @@
 package ch.logixisland.anuto.entity.effect;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -20,7 +21,7 @@ public class AreaObserver implements Entity.Listener {
     private final GameEngine mGameEngine;
     private final Listener mListener;
     private final TickTimer mUpdateTimer = TickTimer.createInterval(0.1f);
-    private final List<Enemy> mEnemiesInArea = new CopyOnWriteArrayList<>();
+    private final HashSet<Enemy> mEnemiesInArea = new HashSet<>();
 
     public interface Listener {
         void enemyEntered(Enemy enemy);
@@ -60,9 +61,10 @@ public class AreaObserver implements Entity.Listener {
     }
 
     private void checkForExitedEnemies() {
-        for (Enemy enemy : mEnemiesInArea) {
+        for (Iterator<Enemy> it = mEnemiesInArea.iterator(); it.hasNext(); ) {
+            Enemy enemy = it.next();
             if (enemy.getDistanceTo(mPosition) > mRange) {
-                mEnemiesInArea.remove(enemy);
+                it.remove();
                 enemy.removeListener(this);
                 mListener.enemyExited(enemy);
             }

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/GlueEffect.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/GlueEffect.java
@@ -1,5 +1,6 @@
 package ch.logixisland.anuto.entity.effect;
 
+import android.graphics.Canvas;
 import android.graphics.Paint;
 
 import ch.logixisland.anuto.R;
@@ -76,9 +77,9 @@ public class GlueEffect extends Effect implements SpriteTransformation, AreaObse
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/HealEffect.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/HealEffect.java
@@ -19,15 +19,13 @@ public class HealEffect extends Effect {
 
     private static final float EFFECT_DURATION = 0.7f;
 
-    private class HealDrawable implements Drawable {
+    private static class StaticData {
         private Paint mPaint;
+    }
 
+
+    private class HealDrawable implements Drawable {
         public HealDrawable() {
-            mPaint = new Paint();
-            mPaint.setStyle(Paint.Style.STROKE);
-            mPaint.setStrokeWidth(0.05f);
-            mPaint.setColor(Color.BLUE);
-            mPaint.setAlpha(70);
         }
 
         @Override
@@ -37,7 +35,7 @@ public class HealEffect extends Effect {
 
         @Override
         public void draw(Canvas canvas) {
-            canvas.drawCircle(getPosition().x(), getPosition().y(), mDrawRadius, mPaint);
+            canvas.drawCircle(getPosition().x(), getPosition().y(), mDrawRadius, mStaticData.mPaint);
         }
     }
 
@@ -47,6 +45,7 @@ public class HealEffect extends Effect {
 
     private Drawable mDrawable;
     private Collection<Enemy> mHealedEnemies;
+    private StaticData mStaticData;
 
     public HealEffect(Entity origin, Vector2 position, float amount, float radius, Collection<Enemy> healedEnemies) {
         super(origin, EFFECT_DURATION);
@@ -56,14 +55,25 @@ public class HealEffect extends Effect {
         mRange = radius;
         mDrawRadius = 0f;
         mHealedEnemies = healedEnemies;
-
         mDrawable = new HealDrawable();
     }
 
     @Override
+    public Object initStatic() {
+        StaticData s = new StaticData();
+        s.mPaint = new Paint();
+
+        s.mPaint.setStyle(Paint.Style.STROKE);
+        s.mPaint.setStrokeWidth(0.05f);
+        s.mPaint.setColor(Color.BLUE);
+        s.mPaint.setAlpha(70);
+        return s;
+    }
+    @Override
     public void init() {
         super.init();
 
+        mStaticData = (StaticData) getStaticData();
         getGameEngine().add(mDrawable);
     }
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/StraightLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/StraightLaser.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -61,7 +62,7 @@ public class StraightLaser extends Effect {
 
     private float mDamage;
     private Vector2 mLaserTo;
-    private Collection<Flyer> mStunnedFliers = new CopyOnWriteArrayList<>();
+    private Collection<Flyer> mStunnedFliers = new ArrayList<>();
 
     private LaserDrawable mDrawObject;
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportEffect.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportEffect.java
@@ -78,7 +78,7 @@ public class TeleportEffect extends Effect implements Entity.Listener {
     @Override
     public void tick() {
         super.tick();
-        mTarget.move(mMoveDirection.mul(mMoveStep));
+        mTarget.move(Vector2.mul(mMoveDirection, mMoveStep));
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportEffect.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportEffect.java
@@ -15,16 +15,12 @@ public class TeleportEffect extends Effect implements Entity.Listener {
 
     private static final float EFFECT_DURATION = 1f;
 
+    private static class StaticData {
+        private Paint mPaint;
+    }
     private class TeleportDrawable implements Drawable {
 
-        private Paint mPaint;
-
         public TeleportDrawable() {
-            mPaint = new Paint();
-            mPaint.setStyle(Paint.Style.STROKE);
-            mPaint.setStrokeWidth(0.1f);
-            mPaint.setColor(Color.MAGENTA);
-            mPaint.setAlpha(70);
         }
 
         @Override
@@ -35,7 +31,7 @@ public class TeleportEffect extends Effect implements Entity.Listener {
         @Override
         public void draw(Canvas canvas) {
             Vector2 target = mTarget.getPosition();
-            canvas.drawLine(getPosition().x(), getPosition().y(), target.x(), target.y(), mPaint);
+            canvas.drawLine(getPosition().x(), getPosition().y(), target.x(), target.y(), mStaticData.mPaint);
         }
 
     }
@@ -46,6 +42,7 @@ public class TeleportEffect extends Effect implements Entity.Listener {
     private Vector2 mMoveDirection;
     private float mMoveStep;
     private TeleportDrawable mDrawObject;
+    private StaticData mStaticData;
 
     public TeleportEffect(Entity origin, Vector2 position, Enemy target, float distance) {
         super(origin, EFFECT_DURATION);
@@ -64,8 +61,14 @@ public class TeleportEffect extends Effect implements Entity.Listener {
     }
 
     @Override
+    public Object initStatic() {
+        return null;
+    }
+
+    @Override
     public void init() {
         super.init();
+        mStaticData = (StaticData) getStaticData();
         getGameEngine().add(mDrawObject);
     }
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportedMarker.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/effect/TeleportedMarker.java
@@ -20,6 +20,7 @@ public class TeleportedMarker extends Effect implements Entity.Listener {
 
     private static class StaticData implements TickListener {
         private SampledFunction mScaleFunction;
+        private Paint mPaint;
 
         @Override
         public void tick() {
@@ -28,13 +29,8 @@ public class TeleportedMarker extends Effect implements Entity.Listener {
     }
 
     private class MarkerDrawable implements Drawable {
-        private Paint mPaint;
 
         private MarkerDrawable() {
-            mPaint = new Paint();
-            mPaint.setStyle(Paint.Style.FILL);
-            mPaint.setColor(Color.MAGENTA);
-            mPaint.setAlpha(30);
         }
 
         @Override
@@ -48,7 +44,7 @@ public class TeleportedMarker extends Effect implements Entity.Listener {
                     getPosition().x(),
                     getPosition().y(),
                     mStaticData.mScaleFunction.getValue(),
-                    mPaint);
+                    mStaticData.mPaint);
         }
     }
 
@@ -73,6 +69,11 @@ public class TeleportedMarker extends Effect implements Entity.Listener {
                 .offset((MARKER_MAX_RADIUS + MARKER_MIN_RADIUS) / 2)
                 .stretch(GameEngine.TARGET_FRAME_RATE / MARKER_SPEED / (float) Math.PI)
                 .sample();
+
+        s.mPaint = new Paint();
+        s.mPaint.setStyle(Paint.Style.FILL);
+        s.mPaint.setColor(Color.MAGENTA);
+        s.mPaint.setAlpha(30);
 
         getGameEngine().add(s);
         return s;

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Blob.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Blob.java
@@ -106,7 +106,7 @@ public class Blob extends Enemy implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Enemy.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Enemy.java
@@ -202,7 +202,7 @@ public abstract class Enemy extends Entity {
             Vector2 wThis = mWayPoints.get(i);
             Vector2 wLast = mWayPoints.get(i - 1);
 
-            dist += wLast.to(wThis).len();
+            dist += wLast.distanceTo(wThis);
         }
 
         return dist;
@@ -218,11 +218,13 @@ public abstract class Enemy extends Entity {
         Vector2 position = getPosition();
 
         while (index < mWayPoints.size()) {
-            Vector2 toWaypoint = position.to(mWayPoints.get(index));
-            float toWaypointDist = toWaypoint.len();
+            Vector2 wayPoint = mWayPoints.get(index);
+            float toWaypointDist = position.distanceTo(wayPoint);
 
             if (distance < toWaypointDist) {
-                return position.add(toWaypoint.mul(distance / toWaypointDist));
+                return Vector2.to(position, wayPoint)
+                              .mul(distance / toWaypointDist)
+                              .add(position);
             }
             distance -= toWaypointDist;
             index++;
@@ -236,16 +238,17 @@ public abstract class Enemy extends Entity {
         Vector2 pos = getPosition();
 
         while (index > 0) {
-            Vector2 wp = mWayPoints.get(index);
-            Vector2 toWp = pos.to(wp);
-            float toWpLen = toWp.len();
+            Vector2 wp = mWayPoints.get(index);;
+            float toWpDist = pos.distanceTo(wp);
 
-            if (dist > toWpLen) {
-                dist -= toWpLen;
+            if (dist > toWpDist) {
+                dist -= toWpDist;
                 pos = wp;
                 index--;
             } else {
-                pos = toWp.norm().mul(dist).add(pos);
+                pos = pos.directionTo(wp)
+                         .mul(dist)
+                         .add(pos);
                 setPosition(pos);
                 mWayPointIndex = index + 1;
                 return;

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/EnemyProperties.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/EnemyProperties.java
@@ -60,11 +60,11 @@ public class EnemyProperties {
     }
 
     public Collection<WeaponType> getWeakAgainst() {
-        return Collections.unmodifiableCollection(mWeakAgainst);
+        return mWeakAgainst;
     }
 
     public Collection<WeaponType> getStrongAgainst() {
-        return Collections.unmodifiableCollection(mStrongAgainst);
+        return mStrongAgainst;
     }
 
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Flyer.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Flyer.java
@@ -121,8 +121,8 @@ public class Flyer extends Enemy implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Healer.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Healer.java
@@ -193,9 +193,9 @@ public class Healer extends Enemy implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mStaticData.mAngle);
-        transformer.scale(mStaticData.mScale);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mStaticData.mAngle);
+        SpriteTransformer.scale(canvas, mStaticData.mScale);
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Healer.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Healer.java
@@ -4,6 +4,7 @@ import android.graphics.Canvas;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
@@ -130,7 +131,7 @@ public class Healer extends Enemy implements SpriteTransformation {
         StaticData s = new StaticData();
 
         s.mHealTimer = TickTimer.createInterval(HEAL_INTERVAL);
-        s.mHealedEnemies = new ArrayList<>();
+        s.mHealedEnemies = new HashSet<>();
 
         s.mScaleFunction = Function.sine()
                 .join(Function.constant(0), (float) Math.PI)

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/HealthBar.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/HealthBar.java
@@ -15,16 +15,20 @@ public class HealthBar implements Drawable {
     private static final float HEALTHBAR_OFFSET = 0.6f;
 
     private final Enemy mEntity;
-    private final Paint mHealthBarBg;
-    private final Paint mHealthBarFg;
+    private static Paint mHealthBarBg = null;
+    private static Paint mHealthBarFg = null;
 
     public HealthBar(Theme theme, Enemy entity) {
         mEntity = entity;
 
-        mHealthBarBg = new Paint();
-        mHealthBarBg.setColor(theme.getColor(R.attr.healthBarBackgroundColor));
-        mHealthBarFg = new Paint();
-        mHealthBarFg.setColor(theme.getColor(R.attr.healthBarColor));
+        if (mHealthBarBg == null) {
+            mHealthBarBg = new Paint();
+            mHealthBarBg.setColor(theme.getColor(R.attr.healthBarBackgroundColor));
+        }
+        if (mHealthBarFg == null) {
+            mHealthBarFg = new Paint();
+            mHealthBarFg.setColor(theme.getColor(R.attr.healthBarColor));
+        }
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Soldier.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Soldier.java
@@ -104,7 +104,7 @@ public class Soldier extends Enemy implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/enemy/Sprinter.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/enemy/Sprinter.java
@@ -117,9 +117,9 @@ public class Sprinter extends Enemy implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/plateau/BasicPlateau.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/plateau/BasicPlateau.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.plateau;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
@@ -73,7 +75,7 @@ public class BasicPlateau extends Plateau implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/CanonShot.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/CanonShot.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
@@ -75,9 +77,9 @@ public class CanonShot extends Shot implements SpriteTransformation, TargetTrack
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/CanonShotMg.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/CanonShotMg.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
 import ch.logixisland.anuto.engine.render.Layers;
@@ -86,8 +88,8 @@ public class CanonShotMg extends Shot implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/GlueShot.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/GlueShot.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
@@ -90,7 +92,7 @@ public class GlueShot extends Shot implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/Mine.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/Mine.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
@@ -169,11 +171,11 @@ public class Mine extends Shot implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
+    public void draw(SpriteInstance sprite, Canvas canvas) {
         float s = mHeightScalingFunction.getValue();
-        transformer.translate(getPosition());
-        transformer.scale(s);
-        transformer.rotate(mAngle);
+        SpriteTransformer.translate(canvas, getPosition());
+        SpriteTransformer.scale(canvas, s);
+        canvas.rotate(mAngle);
     }
 
     public boolean isFlying() {

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/MortarShot.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/MortarShot.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.GameEngine;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
@@ -84,11 +86,11 @@ public class MortarShot extends Shot implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
+    public void draw(SpriteInstance sprite, Canvas canvas) {
         float s = mHeightScalingFunction.getValue();
-        transformer.translate(getPosition());
-        transformer.scale(s);
-        transformer.rotate(mAngle);
+        SpriteTransformer.translate(canvas, getPosition());
+        SpriteTransformer.scale(canvas, s);
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/Rocket.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/Rocket.java
@@ -1,5 +1,7 @@
 package ch.logixisland.anuto.entity.shot;
 
+import android.graphics.Canvas;
+
 import ch.logixisland.anuto.R;
 import ch.logixisland.anuto.engine.logic.entity.Entity;
 import ch.logixisland.anuto.engine.render.Layers;
@@ -109,9 +111,9 @@ public class Rocket extends Shot implements SpriteTransformation, TargetTracker.
         }
     }
 
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/shot/Shot.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/shot/Shot.java
@@ -27,7 +27,7 @@ public abstract class Shot extends Entity {
         super.tick();
 
         if (mEnabled) {
-            move(mDirection.mul(mSpeed / GameEngine.TARGET_FRAME_RATE));
+            move(Vector2.mul(mDirection, mSpeed / GameEngine.TARGET_FRAME_RATE));
         }
     }
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/BouncingLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/BouncingLaser.java
@@ -148,9 +148,9 @@ public class BouncingLaser extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/BouncingLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/BouncingLaser.java
@@ -127,7 +127,7 @@ public class BouncingLaser extends Tower implements SpriteTransformation {
             mAngle = getAngleTo(mAimer.getTarget());
 
             if (isReloaded()) {
-                Vector2 origin = getPosition().add(Vector2.polar(LASER_SPAWN_OFFSET, mAngle));
+                Vector2 origin = Vector2.polar(LASER_SPAWN_OFFSET, mAngle).add(getPosition());
                 getGameEngine().add(new ch.logixisland.anuto.entity.effect.BouncingLaser(
                         this,
                         origin,

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/Canon.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/Canon.java
@@ -164,12 +164,12 @@ public class Canon extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
 
         if (sprite == mSpriteCanon && mReboundActive) {
-            transformer.translate(-mReboundFunction.getValue(), 0);
+            canvas.translate(-mReboundFunction.getValue(), 0);
         }
     }
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/DualCanon.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/DualCanon.java
@@ -214,23 +214,23 @@ public class DualCanon extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
 
         if (sprite == mCanons[0].sprite) {
-            transformer.translate(0, 0.3f);
+            canvas.translate(0, 0.3f);
 
             if (mCanons[0].reboundActive) {
-                transformer.translate(-mCanons[0].reboundFunction.getValue(), 0);
+                canvas.translate(-mCanons[0].reboundFunction.getValue(), 0);
             }
         }
 
         if (sprite == mCanons[1].sprite) {
-            transformer.translate(0, -0.3f);
+            canvas.translate(0, -0.3f);
 
             if (mCanons[1].reboundActive) {
-                transformer.translate(-mCanons[1].reboundFunction.getValue(), 0);
+                canvas.translate(-mCanons[1].reboundFunction.getValue(), 0);
             }
         }
     }

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueGun.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueGun.java
@@ -163,9 +163,9 @@ public class GlueGun extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueGun.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueGun.java
@@ -144,7 +144,7 @@ public class GlueGun extends Tower implements SpriteTransformation {
 
             mAngle = getAngleTo(target);
 
-            Vector2 position = getPosition().add(Vector2.polar(SHOT_SPAWN_OFFSET, getAngleTo(target)));
+            Vector2 position = Vector2.polar(SHOT_SPAWN_OFFSET, getAngleTo(target)).add(getPosition());
             getGameEngine().add(new GlueShot(this, position, target, mGlueIntensity, GLUE_DURATION));
             mSound.play();
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueTower.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueTower.java
@@ -75,10 +75,10 @@ public class GlueTower extends Tower implements SpriteTransformation {
         StaticSprite mSprite;
 
         @Override
-        public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-            transformer.translate(getPosition());
-            transformer.rotate(mAngle);
-            transformer.translate(mCanonOffset, 0);
+        public void draw(SpriteInstance sprite, Canvas canvas) {
+            SpriteTransformer.translate(canvas, getPosition());
+            canvas.rotate(mAngle);
+            canvas.translate(mCanonOffset, 0);
         }
     }
 
@@ -198,8 +198,8 @@ public class GlueTower extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueTower.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/GlueTower.java
@@ -188,7 +188,7 @@ public class GlueTower extends Tower implements SpriteTransformation {
                 mShooting = false;
 
                 for (Vector2 target : mTargets) {
-                    Vector2 position = getPosition().add(Vector2.polar(SHOT_SPAWN_OFFSET, getAngleTo(target)));
+                    Vector2 position = Vector2.polar(SHOT_SPAWN_OFFSET, getAngleTo(target)).add(getPosition());
                     getGameEngine().add(new GlueShot(this, position, target, mGlueIntensity, GLUE_DURATION));
                 }
             }
@@ -233,7 +233,7 @@ public class GlueTower extends Tower implements SpriteTransformation {
                 final Vector2 target = Vector2.polar(dist, angle).add(sect.getPoint1());
 
                 boolean free = StreamIterator.fromIterable(mTargets)
-                        .filter(value -> value.to(target).len() < 0.5f)
+                        .filter(value -> value.distanceTo(target) < 0.5f)
                         .isEmpty();
 
                 if (free) {

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/LevelIndicator.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/LevelIndicator.java
@@ -12,15 +12,17 @@ import ch.logixisland.anuto.util.math.Vector2;
 public class LevelIndicator implements Drawable {
 
     private final Tower mTower;
-    private final Paint mText;
+    private static Paint mText = null;
 
     LevelIndicator(Theme theme, Tower tower) {
         mTower = tower;
 
-        mText = new Paint();
-        mText.setStyle(Paint.Style.FILL);
-        mText.setColor(theme.getColor(R.attr.levelIndicatorColor));
-        mText.setTextSize(100);
+        if (mText == null) {
+            mText = new Paint();
+            mText.setStyle(Paint.Style.FILL);
+            mText.setColor(theme.getColor(R.attr.levelIndicatorColor));
+            mText.setTextSize(100);
+        }
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/MachineGun.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/MachineGun.java
@@ -183,9 +183,9 @@ public class MachineGun extends Tower implements SpriteTransformation {
     }
 
     private Vector2 calcShootingDirection(Enemy target) {
-        Vector2 ps = getPosition().add(getDirectionTo(target).mul(SHOT_SPAWN_OFFSET));
+        Vector2 ps = getDirectionTo(target).mul(SHOT_SPAWN_OFFSET).add(getPosition());
         Vector2 pt = target.getPosition();
-        Vector2 ptToPs = pt.to(ps);
+        float ptToPsAngle = pt.angleTo(ps);
 
         Vector2 dt = target.getDirection();
         if (dt == null) {
@@ -196,10 +196,10 @@ public class MachineGun extends Tower implements SpriteTransformation {
         float vs = CanonShotMg.MOVEMENT_SPEED;
         float vt = target.getSpeed();
 
-        float alpha = dt.angle() - ptToPs.angle();
+        float alpha = dt.angle() - ptToPsAngle;
         float beta = MathUtils.toDegrees((float) Math.asin(vt * Math.sin(MathUtils.toRadians(alpha)) / vs));
 
-        float angle = 180f + ptToPs.angle() - beta;
+        float angle = 180f + ptToPsAngle - beta;
         return Vector2.polar(1f, angle);
     }
 }

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/MachineGun.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/MachineGun.java
@@ -160,9 +160,9 @@ public class MachineGun extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/MineLayer.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/MineLayer.java
@@ -252,8 +252,8 @@ public class MineLayer extends Tower implements SpriteTransformation {
             if (dist > length) {
                 dist -= length;
             } else {
-                return section.lineVector()
-                        .norm()
+                return section
+                        .direction()
                         .mul(dist)
                         .add(section.getPoint1());
             }

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/MineLayer.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/MineLayer.java
@@ -215,9 +215,9 @@ public class MineLayer extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/Mortar.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/Mortar.java
@@ -139,9 +139,9 @@ public class Mortar extends Tower implements SpriteTransformation {
 
         if (mAimer.getTarget() != null && isReloaded()) {
             Vector2 targetPos = mAimer.getTarget().getPositionAfter(MortarShot.TIME_TO_TARGET);
-            targetPos = targetPos.add(Vector2.polar(RandomUtils.next(INACCURACY), RandomUtils.next(360f)));
+            targetPos = Vector2.polar(RandomUtils.next(INACCURACY), RandomUtils.next(360f)).add(targetPos);
             mAngle = getAngleTo(targetPos);
-            Vector2 shotPos = getPosition().add(Vector2.polar(SHOT_SPAWN_OFFSET, mAngle));
+            Vector2 shotPos = Vector2.polar(SHOT_SPAWN_OFFSET, mAngle).add(getPosition());
 
             getGameEngine().add(new MortarShot(this, shotPos, targetPos, getDamage(), mExplosionRadius));
             mSound.play();

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/Mortar.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/Mortar.java
@@ -161,11 +161,11 @@ public class Mortar extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
 
         if (sprite == mSpriteCanon) {
-            transformer.rotate(mAngle);
+            canvas.rotate(mAngle);
         }
     }
 

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/RangeIndicator.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/RangeIndicator.java
@@ -11,14 +11,16 @@ import ch.logixisland.anuto.engine.theme.Theme;
 public class RangeIndicator implements Drawable {
 
     private final Tower mTower;
-    private final Paint mPen;
+    private static Paint mPen = null;
 
     public RangeIndicator(Theme theme, Tower tower) {
         mTower = tower;
-        mPen = new Paint();
-        mPen.setStyle(Paint.Style.STROKE);
-        mPen.setStrokeWidth(0.05f);
-        mPen.setColor(theme.getColor(R.attr.rangeIndicatorColor));
+        if (mPen == null) {
+            mPen = new Paint();
+            mPen.setStyle(Paint.Style.STROKE);
+            mPen.setStrokeWidth(0.05f);
+            mPen.setColor(theme.getColor(R.attr.rangeIndicatorColor));
+        }
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/RocketLauncher.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/RocketLauncher.java
@@ -164,9 +164,9 @@ public class RocketLauncher extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/SimpleLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/SimpleLaser.java
@@ -124,7 +124,7 @@ public class SimpleLaser extends Tower implements SpriteTransformation {
             mAngle = getAngleTo(mAimer.getTarget());
 
             if (isReloaded()) {
-                Vector2 from = getPosition().add(Vector2.polar(LASER_SPAWN_OFFSET, mAngle));
+                Vector2 from = Vector2.polar(LASER_SPAWN_OFFSET, mAngle).add(getPosition());
                 getGameEngine().add(new BouncingLaser(this, from, mAimer.getTarget(), getDamage()));
                 setReloaded(false);
                 mSound.play();

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/SimpleLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/SimpleLaser.java
@@ -138,9 +138,9 @@ public class SimpleLaser extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/StraightLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/StraightLaser.java
@@ -137,9 +137,9 @@ public class StraightLaser extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
-        transformer.rotate(mAngle);
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
+        canvas.rotate(mAngle);
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/StraightLaser.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/StraightLaser.java
@@ -122,8 +122,8 @@ public class StraightLaser extends Tower implements SpriteTransformation {
             mAngle = getAngleTo(mAimer.getTarget());
 
             if (isReloaded()) {
-                Vector2 laserFrom = getPosition().add(Vector2.polar(LASER_SPAWN_OFFSET, mAngle));
-                Vector2 laserTo = getPosition().add(Vector2.polar(LASER_LENGTH, mAngle));
+                Vector2 laserFrom = Vector2.polar(LASER_SPAWN_OFFSET, mAngle).add(getPosition());
+                Vector2 laserTo = Vector2.polar(LASER_LENGTH, mAngle).add(getPosition());
                 getGameEngine().add(new ch.logixisland.anuto.entity.effect.StraightLaser(this, laserFrom, laserTo, getDamage()));
                 setReloaded(false);
                 mSound.play();

--- a/app/src/main/java/ch/logixisland/anuto/entity/tower/Teleporter.java
+++ b/app/src/main/java/ch/logixisland/anuto/entity/tower/Teleporter.java
@@ -148,8 +148,8 @@ public class Teleporter extends Tower implements SpriteTransformation {
     }
 
     @Override
-    public void draw(SpriteInstance sprite, SpriteTransformer transformer) {
-        transformer.translate(getPosition());
+    public void draw(SpriteInstance sprite, Canvas canvas) {
+        SpriteTransformer.translate(canvas, getPosition());
     }
 
     @Override

--- a/app/src/main/java/ch/logixisland/anuto/util/math/Intersections.java
+++ b/app/src/main/java/ch/logixisland/anuto/util/math/Intersections.java
@@ -13,8 +13,8 @@ public final class Intersections {
         Collection<Line> sections = new ArrayList<>();
 
         for (int i = 1; i < wayPoints.size(); i++) {
-            Vector2 p1 = position.to(wayPoints.get(i - 1));
-            Vector2 p2 = position.to(wayPoints.get(i));
+            Vector2 p1 = Vector2.to(position, wayPoints.get(i - 1));
+            Vector2 p2 = Vector2.to(position, wayPoints.get(i));
 
             boolean p1in = p1.len2() <= r2;
             boolean p2in = p2.len2() <= r2;
@@ -25,41 +25,41 @@ public final class Intersections {
             Vector2 sectionP2;
 
             if (p1in && p2in) {
-                sectionP1 = p1.add(position);
-                sectionP2 = p2.add(position);
+                sectionP1 = Vector2.add(p1, position);
+                sectionP2 = Vector2.add(p2, position);
             } else if (!p1in && !p2in) {
                 if (intersections == null) {
                     continue;
                 }
 
-                float a1 = intersections[0].to(p1).angle();
-                float a2 = intersections[0].to(p2).angle();
+                float a1 = intersections[0].angleTo(p1);
+                float a2 = intersections[0].angleTo(p2);
 
                 if (MathUtils.equals(a1, a2, 10f)) {
                     continue;
                 }
 
-                sectionP1 = intersections[0].add(position);
-                sectionP2 = intersections[1].add(position);
+                sectionP1 = Vector2.add(intersections[0], position);
+                sectionP2 = Vector2.add(intersections[1], position);
             } else {
-                float angle = p1.to(p2).angle();
+                float angle = p1.angleTo(p2);
 
                 if (p1in) {
-                    if (MathUtils.equals(angle, p1.to(intersections[0]).angle(), 10f)) {
-                        sectionP2 = intersections[0].add(position);
+                    if (MathUtils.equals(angle, p1.angleTo(intersections[0]), 10f)) {
+                        sectionP2 = Vector2.add(intersections[0], position);
                     } else {
-                        sectionP2 = intersections[1].add(position);
+                        sectionP2 = Vector2.add(intersections[1], position);
                     }
 
-                    sectionP1 = (p1.add(position));
+                    sectionP1 = Vector2.add(p1, position);
                 } else {
-                    if (MathUtils.equals(angle, intersections[0].to(p2).angle(), 10f)) {
-                        sectionP1 = intersections[0].add(position);
+                    if (MathUtils.equals(angle, intersections[0].angleTo(p2), 10f)) {
+                        sectionP1 = Vector2.add(intersections[0], position);
                     } else {
-                        sectionP1 = intersections[1].add(position);
+                        sectionP1 = Vector2.add(intersections[1], position);
                     }
 
-                    sectionP2 = p2.add(position);
+                    sectionP2 = Vector2.add(p2, position);
                 }
             }
 
@@ -70,7 +70,7 @@ public final class Intersections {
     }
 
     private static Vector2[] lineCircle(Vector2 p1, Vector2 p2, float r) {
-        Vector2 d = p1.to(p2);
+        Vector2 d = Vector2.to(p1, p2);
         float dr2 = d.len2();
         float D = p1.x() * p2.y() - p2.x() * p1.y();
 

--- a/app/src/main/java/ch/logixisland/anuto/util/math/Line.java
+++ b/app/src/main/java/ch/logixisland/anuto/util/math/Line.java
@@ -22,16 +22,15 @@ public class Line {
         return mPoint2;
     }
 
-    public Vector2 lineVector() {
-        return mPoint1.to(mPoint2);
-    }
-
     public float length() {
-        return lineVector().len();
+        return mPoint1.distanceTo(mPoint2);
     }
 
     public float angle() {
-        return lineVector().angle();
+        return mPoint1.angleTo(mPoint2);
     }
 
+    public Vector2 direction() {
+        return mPoint1.directionTo(mPoint2);
+    }
 }

--- a/app/src/main/java/ch/logixisland/anuto/util/math/Vector2.java
+++ b/app/src/main/java/ch/logixisland/anuto/util/math/Vector2.java
@@ -9,6 +9,22 @@ public class Vector2 {
         );
     }
 
+    public static Vector2 add(Vector2 a, Vector2 b) {
+        return new Vector2(a.x + b.x, a.y + b.y);
+    }
+
+    public static Vector2 sub(Vector2 a, Vector2 b) {
+        return new Vector2(a.x - b.x, a.y - b.y);
+    }
+
+    public static Vector2 to(Vector2 a, Vector2 b) {
+        return new Vector2(b.x - a.x, b.y - a.y);
+    }
+
+    public static Vector2 mul(Vector2 v, float s) {
+        return new Vector2(v.x * s, v.y * s);
+    }
+
     private float x;
     private float y;
 
@@ -30,20 +46,18 @@ public class Vector2 {
         return y;
     }
 
+    // Like add() but overwrites the source object instead of allocating
     public Vector2 add(Vector2 v) {
-        return new Vector2(this.x + v.x, this.y + v.y);
+        this.x = this.x + v.x;
+        this.y = this.y + v.y;
+        return this;
     }
 
-    public Vector2 sub(Vector2 v) {
-        return new Vector2(this.x - v.x, this.y - v.y);
-    }
-
-    public Vector2 to(Vector2 v) {
-        return new Vector2(v.x - this.x, v.y - this.y);
-    }
-
+    // Like mul() but overwrites the source object instead of allocating
     public Vector2 mul(float s) {
-        return new Vector2(this.x * s, this.y * s);
+        this.x = this.x * s;
+        this.y = this.y * s;
+        return this;
     }
 
     public Vector2 div(float s) {
@@ -54,8 +68,12 @@ public class Vector2 {
         return x * v.x + y * v.y;
     }
 
-    public float len() {
+    private static float len(float x, float y) {
         return (float) Math.sqrt(x * x + y * y);
+    }
+
+    public float len() {
+        return len(x, y);
     }
 
     public float len2() {
@@ -68,11 +86,33 @@ public class Vector2 {
 
     public Vector2 proj(Vector2 v) {
         float f = this.dot(v) / v.len2();
-        return v.mul(f);
+        return Vector2.mul(v, f);
+    }
+
+    private static float angle(float x, float y) {
+        return MathUtils.toDegrees((float) Math.atan2(y, x));
     }
 
     public float angle() {
-        return MathUtils.toDegrees((float) Math.atan2(y, x));
+        return angle(this.x, this.y);
+    }
+
+    // equivalent to v.to(x).len()
+    public float distanceTo(Vector2 v) {
+        return len(v.x - this.x, v.y - this.y);
+    }
+
+    // equivalent to v.to(x).angle()
+    public float angleTo(Vector2 v) {
+        return angle(v.x - this.x, v.y - this.y);
+    }
+
+    public Vector2 directionTo(Vector2 v) {
+        Vector2 to = Vector2.to(this, v);
+        float len = to.len();
+        to.x /= len;
+        to.y /= len;
+        return to;
     }
 
     @Override


### PR DESCRIPTION
Contributes to #141 on the lower level.

This greatly reduces memory and CPU usage without touching any algorithms.

 - Change most Vector2 operations to be destructive ( `+=` ) if possible, returning the `this` pointer instead of a new vector.
   - Non-destructive ones now use static methods
   - Some operations were shifted to allow this to work.
 - Add more complex Vector2 functions that do not use temporaries (distance, angle, direction)
 - Convert SpriteTransformer to static methods and directly pass the Canvas to the callback instead.
 - Make `Paint` brushes static if possible
 - Convert some ArrayLists to HashSets if applicable, allowing O(1) `contains` lookup
 - Avoid creating UnmodifiableList/UnmodifiableCollection instances, instead return the list directly.